### PR TITLE
feat(ci): Use latest GH Actions runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest', 'windows-latest' ]
+        os: [ 'ubuntu-24.04', 'windows-2025' ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repo"
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24.04' ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: "Checkout repo"
@@ -60,7 +60,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ 'ubuntu-latest' ]
+        os: [ 'ubuntu-24.04' ]
         include:
           - language: csharp
             build-mode: manual

--- a/.github/workflows/pr-management.yml
+++ b/.github/workflows/pr-management.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   add-pr-labels:
-    runs-on: [ 'ubuntu-latest' ]
+    runs-on: [ 'ubuntu-24.04' ]
     steps:
       - name: 'Run script'
         uses: actions/github-script@v7
@@ -57,7 +57,7 @@ jobs:
             }
 
   validate-title:
-    runs-on: [ 'ubuntu-latest' ]
+    runs-on: [ 'ubuntu-24.04' ]
     steps:
       - uses: amannn/action-semantic-pull-request@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: write-all
 jobs:
   release-please:
     name: 'Release-Please'
-    runs-on: [ 'ubuntu-latest' ]
+    runs-on: [ 'ubuntu-24.04' ]
     outputs:
         releases_created: ${{ steps.run-release-please.outputs.releases_created }}
         tag_name: ${{ steps.run-release-please.outputs.tag_name }}
@@ -35,7 +35,7 @@ jobs:
 
   release-nxio:
     name: 'Nxio - ${{ matrix.rid }} - ${{ matrix.self-contained }}'
-    runs-on: [ 'ubuntu-latest' ]
+    runs-on: [ 'ubuntu-24.04' ]
     needs: 'release-please'
     strategy:
       fail-fast: false


### PR DESCRIPTION
This pull request includes updates to the CI/CD workflows to use the latest operating system versions. The most important changes involve updating the `runs-on` parameter across multiple workflow files to specify `ubuntu-24.04` instead of `ubuntu-latest`.

Changes to CI workflows:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL20-R20): Updated the `os` matrix to use `ubuntu-24.04` and `windows-2025` for various jobs. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL20-R20) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL43-R43) [[3]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL63-R63)

Changes to PR management workflows:

* [`.github/workflows/pr-management.yml`](diffhunk://#diff-7f6b8d3a8e74d38d553992c35862eecaa9e72d73d6fe58469846333b957ab8e9L13-R13): Updated the `runs-on` parameter to use `ubuntu-24.04` for `add-pr-labels` and `validate-title` jobs. [[1]](diffhunk://#diff-7f6b8d3a8e74d38d553992c35862eecaa9e72d73d6fe58469846333b957ab8e9L13-R13) [[2]](diffhunk://#diff-7f6b8d3a8e74d38d553992c35862eecaa9e72d73d6fe58469846333b957ab8e9L60-R60)

Changes to release workflows:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L12-R12): Updated the `runs-on` parameter to use `ubuntu-24.04` for `release-please` and `release-nxio` jobs. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L12-R12) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L38-R38)