### PR TITLE
feat(bot): Add mute text command & "Unmute" background service

### DIFF
--- a/Nxio.Bot/BackgroundWorkers/MuteWorker.cs
+++ b/Nxio.Bot/BackgroundWorkers/MuteWorker.cs
@@ -64,7 +64,7 @@ public class MuteWorker(ILogger<MuteWorker> logger, IServiceProvider serviceProv
                     await dbContext.SaveChangesAsync(cancellationToken: stoppingToken);
             }
 
-            await Task.Delay(60 * 1_000, stoppingToken);
+            await Task.Delay(30 * 1_000, stoppingToken);
         }
 
         logger.LogDebug("Worker stopped at: {Time}", DateTimeOffset.UtcNow);

--- a/Nxio.Bot/BackgroundWorkers/MuteWorker.cs
+++ b/Nxio.Bot/BackgroundWorkers/MuteWorker.cs
@@ -6,7 +6,7 @@ using Nxio.Core.Extensions;
 
 namespace Nxio.Bot.BackgroundWorkers;
 
-public class MuteWorker(ILogger<MuteWorker> logger, BaseDbContext dbContext, RestClient client) : BackgroundService
+public class MuteWorker(ILogger<MuteWorker> logger, IServiceProvider serviceProvider, RestClient client) : BackgroundService
 {
     protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
@@ -16,6 +16,9 @@ public class MuteWorker(ILogger<MuteWorker> logger, BaseDbContext dbContext, Res
         while (!stoppingToken.IsCancellationRequested)
         {
             logger.LogDebug("Worker running at: {Time}", DateTimeOffset.UtcNow);
+
+            await using var scope = serviceProvider.CreateAsyncScope();
+            var dbContext = scope.ServiceProvider.GetRequiredService<BaseDbContext>();
 
             var mutedUsers = await dbContext.UserMutes.Where(x => x.MuteEndUtc < DateTimeOffset.UtcNow).ToListAsync(cancellationToken: stoppingToken);
             if (mutedUsers.Count != 0)
@@ -44,10 +47,13 @@ public class MuteWorker(ILogger<MuteWorker> logger, BaseDbContext dbContext, Res
                     if (muteRole != 0)
                         await client.RemoveGuildUserRoleAsync(userId: user.UserId, guildId: user.GuildId, roleId: muteRole, cancellationToken: stoppingToken);
 
-                    foreach (var roleId in user.RoleIdsBeforeMute.Split(';'))
+                    foreach (var roleId in user.RoleIdsBeforeMute.Split(';').Where(x => !string.IsNullOrWhiteSpace(x)))
                     {
-                        if (!string.IsNullOrWhiteSpace(roleId) && ulong.TryParse(roleId, out var roleIdParsed))
+                        if (ulong.TryParse(roleId, out var roleIdParsed))
+                        {
+                            logger.LogDebug("Adding role {RoleId} to user {UserId} in guild {GuildId}", roleIdParsed, user.UserId, user.GuildId);
                             await client.AddGuildUserRoleAsync(userId: user.UserId, guildId: user.GuildId, roleId: roleIdParsed, cancellationToken: stoppingToken);
+                        }
                     }
 
                     dbContext.UserMutes.Remove(user);

--- a/Nxio.Bot/Modules/Common/MuteCommand.cs
+++ b/Nxio.Bot/Modules/Common/MuteCommand.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore;
+using NetCord;
+using NetCord.Gateway;
+using NetCord.Rest;
+using Nxio.Core;
+using Nxio.Core.Database;
+using Nxio.Core.Database.Models;
+using Nxio.Core.Database.Models.Enums;
+using Nxio.Core.Extensions;
+using User = Nxio.Core.Database.Models.User;
+
+namespace Nxio.Bot.Modules.Common;
+
+public static class MuteCommand
+{
+    private static readonly Color RedColor = new(red: 255, green: 0, blue: 0);
+    private static readonly Color GreenColor = new(red: 0, green: 255, blue: 0);
+
+    public static async Task<(EmbedProperties embed, bool ephemeral)> Run(ILogger logger, BaseDbContext dbContext, GuildUser targetUser, GatewayClient botUser, NetCord.User commandAuthor, int timeInMinutes, string? reason, Guild guild)
+    {
+        if (targetUser.Id == commandAuthor.Id) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't shoot yourself", Color = RedColor }, true);
+        if (targetUser.IsBot || targetUser.IsSystemUser == true) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't shoot a Bot/SystemUser!" }, true);
+
+        var guildSetting = await dbContext.GuildSettings.FirstOrDefaultAsync(x => x.GuildId == guild.Id && x.Name == GuildSettingName.DefaultMuteRole);
+        if (guildSetting == null) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "No default mute role set!" }, true);
+        var guildMuteRole = guildSetting.GetGuildSettingValue<ulong>();
+
+
+        var targetRoles = targetUser.GetRoles(guild).ToList();
+        // var triggerRolePos = (await guild.GetUserAsync(commandAuthor.Id)).GetRoles(guild);
+        // if (targetRoles.Any(x => x.Position > triggerRolePos)) return "You can't shoot someone with a higher role than you!";
+        if (targetRoles.Any(x => (x.Permissions & Permissions.Administrator) != 0)) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You mute an admin!", Color = RedColor }, true);
+
+        var dbCommandVictim = await dbContext.UserMutes.FirstOrDefaultAsync(x => x.UserId == targetUser.Id);
+        if (dbCommandVictim != null) dbCommandVictim.MuteEndUtc = DateTimeOffset.UtcNow.AddMinutes(timeInMinutes);
+        else
+        {
+            dbCommandVictim = new UserMute
+            {
+                GuildId = guild.Id,
+                UserId = targetUser.Id,
+                MuteStartUtc = DateTimeOffset.UtcNow,
+                MuteEndUtc = DateTimeOffset.UtcNow.AddMinutes(timeInMinutes),
+                RoleIdsBeforeMute = string.Join(";", targetRoles.Select(x => x.Id)),
+            };
+
+            await dbContext.UserMutes.AddAsync(dbCommandVictim);
+        }
+
+        foreach (var role in targetRoles.DistinctBy(role => role.Id))
+        {
+            logger.LogDebug("Removing: {Role}", role.Name);
+            await guild.RemoveUserRoleAsync(targetUser.Id, role.Id);
+        }
+
+        await guild.AddUserRoleAsync(targetUser.Id, guildMuteRole);
+
+        await dbContext.SaveChangesAsync();
+
+        var embed = new EmbedProperties
+        {
+            Author = new EmbedAuthorProperties { Name = commandAuthor.Username, IconUrl = commandAuthor.GetAvatarUrl()?.ToString() },
+            Description = $"Muted <@{targetUser.Id}> for {timeInMinutes} minutes!\nReason: {reason}\nMute will end approximately <t:{dbCommandVictim.MuteEndUtc.ToUnixTimeSeconds()}:R>",
+            Color = GreenColor
+        };
+
+        var dmChannel = await targetUser.GetDMChannelAsync();
+        await dmChannel.SendMessageAsync(new MessageProperties { Embeds = [embed] });
+
+        return new ValueTuple<EmbedProperties, bool>(embed, false);
+    }
+}

--- a/Nxio.Bot/Modules/Common/MuteCommand.cs
+++ b/Nxio.Bot/Modules/Common/MuteCommand.cs
@@ -27,8 +27,8 @@ public static class MuteCommand
         var botRoles = (await guild.GetUserAsync(botUser.Id)).GetRoles(guild).ToList();
         var targetRoles = targetUser.GetRoles(guild).ToList();
         var triggerRolePos = (await guild.GetUserAsync(commandAuthor.Id)).GetRoles(guild);
-        if (targetRoles.Any(x => triggerRolePos.Any(y=>x.Position>y.Position))) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't mute with someone of higher role than you!", Color = RedColor }, true);
-        if(targetRoles.Any(x=>botRoles.Any(y=>x.Position>y.Position))) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't mute someone with higher role than me!", Color = RedColor }, true);
+        if (targetRoles.Any(x => triggerRolePos.Any(y => x.Position > y.Position))) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't mute with someone of higher role than you!", Color = RedColor }, true);
+        if (targetRoles.Any(x => botRoles.Any(y => x.Position > y.Position))) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't mute someone with higher role than me!", Color = RedColor }, true);
         if (targetRoles.Any(x => (x.Permissions & Permissions.Administrator) != 0)) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't mute an admin!", Color = RedColor }, true);
 
         var dbCommandVictim = await dbContext.UserMutes.FirstOrDefaultAsync(x => x.UserId == targetUser.Id);

--- a/Nxio.Bot/Modules/Common/MuteCommand.cs
+++ b/Nxio.Bot/Modules/Common/MuteCommand.cs
@@ -2,12 +2,10 @@
 using NetCord;
 using NetCord.Gateway;
 using NetCord.Rest;
-using Nxio.Core;
 using Nxio.Core.Database;
 using Nxio.Core.Database.Models;
 using Nxio.Core.Database.Models.Enums;
 using Nxio.Core.Extensions;
-using User = Nxio.Core.Database.Models.User;
 
 namespace Nxio.Bot.Modules.Common;
 

--- a/Nxio.Bot/Modules/Common/MuteCommand.cs
+++ b/Nxio.Bot/Modules/Common/MuteCommand.cs
@@ -24,10 +24,12 @@ public static class MuteCommand
         var guildMuteRole = guildSetting.GetGuildSettingValue<ulong>();
 
 
+        var botRoles = (await guild.GetUserAsync(botUser.Id)).GetRoles(guild).ToList();
         var targetRoles = targetUser.GetRoles(guild).ToList();
-        // var triggerRolePos = (await guild.GetUserAsync(commandAuthor.Id)).GetRoles(guild);
-        // if (targetRoles.Any(x => x.Position > triggerRolePos)) return "You can't shoot someone with a higher role than you!";
-        if (targetRoles.Any(x => (x.Permissions & Permissions.Administrator) != 0)) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You mute an admin!", Color = RedColor }, true);
+        var triggerRolePos = (await guild.GetUserAsync(commandAuthor.Id)).GetRoles(guild);
+        if (targetRoles.Any(x => triggerRolePos.Any(y=>x.Position>y.Position))) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't mute with someone of higher role than you!", Color = RedColor }, true);
+        if(targetRoles.Any(x=>botRoles.Any(y=>x.Position>y.Position))) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't mute someone with higher role than me!", Color = RedColor }, true);
+        if (targetRoles.Any(x => (x.Permissions & Permissions.Administrator) != 0)) return new ValueTuple<EmbedProperties, bool>(new EmbedProperties { Description = "You can't mute an admin!", Color = RedColor }, true);
 
         var dbCommandVictim = await dbContext.UserMutes.FirstOrDefaultAsync(x => x.UserId == targetUser.Id);
         if (dbCommandVictim != null) dbCommandVictim.MuteEndUtc = DateTimeOffset.UtcNow.AddMinutes(timeInMinutes);

--- a/Nxio.Bot/Modules/MuteModuleText.cs
+++ b/Nxio.Bot/Modules/MuteModuleText.cs
@@ -1,0 +1,25 @@
+﻿using JetBrains.Annotations;
+using NetCord;
+using NetCord.Rest;
+using NetCord.Services.Commands;
+using Nxio.Bot.Modules.Common;
+using Nxio.Core.Database;
+
+namespace Nxio.Bot.Modules;
+
+[UsedImplicitly(ImplicitUseTargetFlags.WithMembers, Reason = "Registered via module discovery")]
+public class MuteModuleText(ILogger<MuteModuleText> logger, BaseDbContext dbContext) : CommandModule<CommandContext>
+{
+    [Command("mute", "m")]
+    public async Task<ReplyMessageProperties> Mute(
+        [CommandParameter(Name = "user")] GuildUser targetUser,
+        [CommandParameter(Name = "duration")] int timeInMinutes, // TODO" Rewrite to accept 12h, 1d, 1w, etc. syntax
+        [CommandParameter(Name = "reason", Remainder = true)] string reason = "No reason provided"
+    )
+    {
+        logger.LogDebug("Guild: {Guild} | User: {User} ({UserId})", Context.Guild!.Name, Context.User.Username, Context.User.Id);
+        if (Context.Guild == null) return new ReplyMessageProperties { Content = "This command can only be used in a guild!" };
+        var (embed, _) = await MuteCommand.Run(logger, dbContext, targetUser, Context.Client, Context.User, timeInMinutes, reason, Context.Guild);
+        return new ReplyMessageProperties { Embeds = [embed] };
+    }
+}

--- a/Nxio.Bot/Program.cs
+++ b/Nxio.Bot/Program.cs
@@ -19,7 +19,6 @@ public static class Program
         var builder = Host.CreateApplicationBuilder(args);
 
         builder.Services
-            .AddHostedService<MuteWorker>()
             .AddGatewayEventHandlers(typeof(Program).Assembly)
             .AddApplicationCommands<ApplicationCommandInteraction, ApplicationCommandContext>(op => op.ResultHandler = new ApplicationCommandResultHandler<ApplicationCommandContext>(MessageFlags.Ephemeral))
             .AddCommands<CommandContext>(op => op.IgnoreCase = true)
@@ -36,7 +35,8 @@ public static class Program
 #if DEBUG
                 op.EnableSensitiveDataLogging();
 #endif
-            });
+            })
+            .AddSingleton<IHostedService, MuteWorker>();
 
         var host = builder
             .Build()

--- a/Nxio.Core/Database/BaseDbContext.cs
+++ b/Nxio.Core/Database/BaseDbContext.cs
@@ -18,5 +18,5 @@ public class BaseDbContext(DbContextOptions<BaseDbContext> options) : DbContext(
     public DbSet<User> Users { get; set; } = default!;
     public DbSet<Upgrade> Upgrades { get; set; } = default!;
     public DbSet<GuildSettings> GuildSettings { get; set; } = default!;
-    public DbSet<UserMutes> UserMutes { get; set; } = default!;
+    public DbSet<UserMute> UserMutes { get; set; } = default!;
 }

--- a/Nxio.Core/Database/Configurations/UserMutesConfiguration.cs
+++ b/Nxio.Core/Database/Configurations/UserMutesConfiguration.cs
@@ -4,9 +4,9 @@ using Nxio.Core.Database.Models;
 
 namespace Nxio.Core.Database.Configurations;
 
-public class UserMutesConfiguration : IEntityTypeConfiguration<UserMutes>
+public class UserMutesConfiguration : IEntityTypeConfiguration<UserMute>
 {
-    public void Configure(EntityTypeBuilder<UserMutes> builder)
+    public void Configure(EntityTypeBuilder<UserMute> builder)
     {
         builder.HasKey(x => x.Id);
         builder.Property(x => x.UserId).IsRequired();

--- a/Nxio.Core/Database/Migrations/20241225182330_AddUserMutes.Designer.cs
+++ b/Nxio.Core/Database/Migrations/20241225182330_AddUserMutes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Nxio.Core.Database;
 
@@ -11,9 +12,11 @@ using Nxio.Core.Database;
 namespace Nxio.Core.Database.Migrations
 {
     [DbContext(typeof(BaseDbContext))]
-    partial class BaseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241225182330_AddUserMutes")]
+    partial class AddUserMutes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Nxio.Core/Database/Migrations/20241225182330_AddUserMutes.cs
+++ b/Nxio.Core/Database/Migrations/20241225182330_AddUserMutes.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Nxio.Core.Database.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserMutes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "GuildSettings",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    GuildId = table.Column<decimal>(type: "decimal(20,0)", nullable: false),
+                    Name = table.Column<int>(type: "int", nullable: false),
+                    Value = table.Column<string>(type: "nvarchar(512)", maxLength: 512, nullable: false),
+                    Type = table.Column<int>(type: "int", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_GuildSettings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "UserMutes",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uniqueidentifier", nullable: false),
+                    UserId = table.Column<decimal>(type: "decimal(20,0)", nullable: false),
+                    GuildId = table.Column<decimal>(type: "decimal(20,0)", nullable: false),
+                    MuteStartUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    MuteEndUtc = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false),
+                    RoleIdsBeforeMute = table.Column<string>(type: "nvarchar(max)", maxLength: 6000, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_UserMutes", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "GuildSettings");
+
+            migrationBuilder.DropTable(
+                name: "UserMutes");
+        }
+    }
+}

--- a/Nxio.Core/Database/Models/UserMute.cs
+++ b/Nxio.Core/Database/Models/UserMute.cs
@@ -1,6 +1,6 @@
 ﻿namespace Nxio.Core.Database.Models;
 
-public class UserMutes : DbEntity<Guid>
+public class UserMute : DbEntity<Guid>
 {
     public required ulong UserId { get; set; }
     public required ulong GuildId { get; set; }


### PR DESCRIPTION
This pull request includes several significant changes to the `Nxio.Bot` project, focusing on refactoring the `MuteWorker` class, adding a new `MuteCommand`, and updating database configurations and migrations. The most important changes are summarized below:

Improvements to `MuteWorker`:

* [`Nxio.Bot/BackgroundWorkers/MuteWorker.cs`](diffhunk://#diff-72a98df24c782ca73c4f85f46a660fd6c5923ce3c72153d8836317c967dc9486L9-R9): Refactored the `MuteWorker` class to use `IServiceProvider` instead of directly injecting `BaseDbContext`, allowing for better dependency management and scope handling. [[1]](diffhunk://#diff-72a98df24c782ca73c4f85f46a660fd6c5923ce3c72153d8836317c967dc9486L9-R9) [[2]](diffhunk://#diff-72a98df24c782ca73c4f85f46a660fd6c5923ce3c72153d8836317c967dc9486R20-R22) [[3]](diffhunk://#diff-72a98df24c782ca73c4f85f46a660fd6c5923ce3c72153d8836317c967dc9486L47-R57)

New `MuteCommand` implementation:

* [`Nxio.Bot/Modules/Common/MuteCommand.cs`](diffhunk://#diff-1bbc01656296de798d45161536b22ee3dc8a75b8a0e8833622519a4e7f7724cfR1-R72): Added a new static class `MuteCommand` with a method to handle muting users, including updating the database and sending notifications.
* [`Nxio.Bot/Modules/MuteModuleText.cs`](diffhunk://#diff-032861168515f6713c937d5ecb3ac0abb56a96385f4e092e111913577c03b0c4R1-R25): Introduced `MuteModuleText` class to register the mute command and handle command execution.

Database updates:

* [`Nxio.Core/Database/BaseDbContext.cs`](diffhunk://#diff-f7e8d4e0ad16087452f718558c15133c240b082cace5c55b5a1d62859eb100efL21-R21): Renamed `UserMutes` DbSet to `UserMutes` for consistency.
* [`Nxio.Core/Database/Configurations/UserMutesConfiguration.cs`](diffhunk://#diff-dc17c9123a66aaa43d7ea17d9891e8a007eeb2a57be92b0eaf7cc487f54d169aL7-R9): Updated the configuration class to match the new `UserMute` entity name.
* Added new migration files to create the `UserMutes` table and update the database schema accordingly. [[1]](diffhunk://#diff-d63eaec5290efc2f6779288089b392642da33b3525bfc6018477bd887dae2033R1-R266) [[2]](diffhunk://#diff-58d779d5aad7f6ca08dd72854a26e911aee82812c8fd957e2474d7ac034a6747R1-R56) [[3]](diffhunk://#diff-b9d528535dafdffb139364ad54fffdb414fac812b340f6f1949d152ecbe6e53bR66-R90)

Changes to program initialization:

* [`Nxio.Bot/Program.cs`](diffhunk://#diff-777d40a6a58d97e193ad644aac5243436dcda6b432dcd01d56caf47d93f8eb37L22): Modified the program initialization to register `MuteWorker` as a singleton hosted service. [[1]](diffhunk://#diff-777d40a6a58d97e193ad644aac5243436dcda6b432dcd01d56caf47d93f8eb37L22) [[2]](diffhunk://#diff-777d40a6a58d97e193ad644aac5243436dcda6b432dcd01d56caf47d93f8eb37L39-R39)